### PR TITLE
add if condition check to handle JSON field value: 0 and empty string

### DIFF
--- a/json-path-processor.js
+++ b/json-path-processor.js
@@ -20,7 +20,7 @@ var lodash = require('lodash'),
                 continue;
             }
 
-            if (OO[key]) {
+            if (OO[key] !== undefined && OO[key] !== null) {
                 OO = OO[key];
             } else {
                 if (create !== undefined) {

--- a/test/test.js
+++ b/test/test.js
@@ -311,4 +311,14 @@ describe('json-path-processor', function () {
         }).value(), {a: {b: {c: [3, 5], d:5}}});
         done();
     });
+
+    it('should return 0', function (done) {
+        assert.equal(0, jpp({a: {b: {c: 0}}}, 'a.b.c'));
+        done();
+    });
+
+    it('should return empty string', function (done) {
+        assert.equal("", jpp({a: {b: {c: ""}}}, 'a.b.c'));
+        done();
+    });
 });


### PR DESCRIPTION
While JSON field value is 0 or empty string, value() returns undefined not the right value. This patch adds condition check to handle the case. Test cases are also included.
ex:
var J = jpp({a: {b: {c: 0}}});
console.log(J.value('a.b.c'));
