### PR TITLE
added [DOT] variable to allow . in keys

### DIFF
--- a/json-path-processor.js
+++ b/json-path-processor.js
@@ -12,7 +12,7 @@ var jsonpath = function (obj, path, assign, create, del) {
         }
 
         while (P.length) {
-            key = P.pop();
+            key = P.pop().replace('[DOT]', '.');
             switch (key) {
             case '$':
             case '':


### PR DESCRIPTION
This is a simple change to allow the use of paths that have a . in the property name:

    jpp({}).set('internet.sites.google[DOT]com', 'test').value()

__returns__

    {internet: {sites: {"google.com": 'test'}}}