### PR TITLE
Fix for issue where it is impossible to set a path to null

### DIFF
--- a/json-path-processor.js
+++ b/json-path-processor.js
@@ -44,7 +44,7 @@ var jsonpath = function (obj, path, assign, create, del) {
                 continue;
             }
 
-            if ((OO[key] !== undefined) && (OO[key] !== null)) {
+            if ((OO[key] !== undefined)) {
                 OO = OO[key];
             } else {
                 if (create !== undefined) {

--- a/json-path-processor.js
+++ b/json-path-processor.js
@@ -74,9 +74,9 @@ var jsonpath = function (obj, path, assign, create, del) {
         if (assign !== undefined) {
             try {
                 if (key) {
-                    O[key] = assign.call ? assign(OO) : assign;
+                    O[key] = assign !== null && assign.call ? assign(OO) : assign;
                 } else {
-                    O = assign.call ? assign(OO) : assign;
+                    O = assign !== null && assign.call ? assign(OO) : assign;
                 }
             } catch (E) {
                 if (create && key) {
@@ -96,7 +96,7 @@ function JPP (data) {
 
 JPP.prototype = {
     value: function (path) {
-        if (!this._data) { 
+        if (!this._data) {
             return this._data;
         }
         return path ? jsonpath(this._data, path) : this._data;
@@ -280,7 +280,7 @@ JPP.prototype = {
             this.set(arguments[0], all, true);
         }
 
-        return this; 
+        return this;
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,13 @@ describe('jpp', function () {
             done();
         });
 
+        it('should return null when the value is null', function (done) {
+            var J = jpp({a: {b: {c: null}}});
+
+            assert.equal(J.value('a.b.c'), null);
+            done();
+        });
+
         it('should return undefined when not found', function (done) {
             var J = jpp({a: {b: {c: 'OK!'}}});
 

--- a/test/test.js
+++ b/test/test.js
@@ -11,14 +11,14 @@ describe('jpp', function () {
 
     it('should create an object', function (done) {
         var J = jpp([1, 2, 3]);
-        assert.equal(typeof J, 'object'); 
+        assert.equal(typeof J, 'object');
         done();
     });
 
     it('should create a jpp chained object', function (done) {
         var J = jpp([1, 2, 3]);
         assert.deepEqual(J.value(), [1, 2, 3]);
-        done(); 
+        done();
     });
 
     describe('.value()', function () {
@@ -90,6 +90,13 @@ describe('jpp', function () {
             var J = jpp({a: {b: {c: 'OK!'}}});
 
             assert.deepEqual(J.set('$.a.b.c', 0).value(), {a: {b: {c: 0}}});
+            done();
+        });
+
+        it('should handle set to null', function (done) {
+            var J = jpp({a: {b: {c: 'OK!'}}});
+
+            assert.deepEqual(J.set('$.a.b.c', null).value(), {a: {b: {c: null}}});
             done();
         });
 


### PR DESCRIPTION
I've experienced an issue whereby I cannot set a value to null, so when I do:

`var J = jpp({
  a: {
    b: {
      c: 'OK!'
    }
  }
});
J.set('$.a.b.c', null, "a truthy value");`

; I would get:

`{
  a : {
    b : {
      c : "a truthy value"
    }
  }
}`

; instead of:

`{
  a : {
    b : {
      c : null
    }
  }
}`

Fixed this issue and added a test case for it.